### PR TITLE
check for undefined package.json

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -303,7 +303,7 @@ export function LoggerAdaptToConsole(options?: { logLevel?: LOG_LEVEL; debugStri
   // log package name
   packageName = '';
   const jsonPackage = require(path.join(appRootPath.toString(), 'package.json'));
-  packageName = jsonPackage.name || '';
+  packageName = jsonPackage?.name || '';
 
   Logger.level = logParams.logLevel;
 


### PR DESCRIPTION
The package.json may not be available at runtime. This prevents the library from throwing an exception when trying to read the name from undefined.